### PR TITLE
Slice 9d-N: CSC axis=0 thread-bucket memory fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,27 @@
 # dafr (development version)
 
+## Slice 9d-N — CSC axis-0 row-partition sweep (2026-04-22)
+
+### Performance
+
+* **Row-partition rewrite of the axis = 0 branch of six non-grouped
+  CSC kernels.** Four category-A kernels (`kernel_var_csc`,
+  `kernel_minmax_csc`, `kernel_log_reduce`, `kernel_geomean_csc`) each
+  carried a `std::vector<std::vector<T>>` of length `nthreads × nrow`
+  that was merged serially after the parallel scan; two category-B
+  kernels (`kernel_mode_csc`, `kernel_quantile_csc`) had a single-
+  threaded fill pass because `rows[pi[k]].push_back(...)` would race
+  across threads. The rewrite applies the 9d-M row-partition template
+  inline: each thread owns a disjoint row range `[r0, r1)` and writes
+  directly into the shared output-shaped accumulator, with post-process
+  folded into the same parallel region. Combined peak-RSS reduction on
+  a 10⁵ × 5·10³ × 0.02 stress fixture at 128 threads is measured in
+  hundreds of MB for category-A kernels; category-B kernels gain
+  parallel fill for the first time. Bit-identity with serial dispatch
+  is preserved — values accumulate in column-ascending order per row
+  in both paths. No bake-off regression; the fix is memory-and-perf at
+  scale, invisible at OMP\_NUM\_THREADS = 1.
+
 ## Slice 9d-M — G3 grouped-CSC memory fix (2026-04-22)
 
 ### Performance

--- a/src/kernel_geomean_csc.cpp
+++ b/src/kernel_geomean_csc.cpp
@@ -66,8 +66,9 @@ cpp11::writable::doubles kernel_geomean_csc_cpp(
         return out;
     }
 
-    // axis == 0: per-row. Thread-bucket accumulation pattern (same as
-    // kernel_log_reduce_csc_cpp, kernel_var_csc_cpp).
+    // axis == 0: per-row. Row-partition: each thread owns a disjoint row
+    // range [r0, r1); writes to pout[r] and nnz_per_row[r] are race-free.
+    // No thread buckets, no serial merge.
     cpp11::writable::doubles out(nrow);
     double *pout = REAL(out.data());
 
@@ -77,47 +78,37 @@ cpp11::writable::doubles kernel_geomean_csc_cpp(
         return out;
     }
 
-    // FIXME: tsum/tnnz are O(nthreads * nrow). For scRNA-seq-scale inputs
-    // (nrow > 1e6), consider a sequential fallback.
-    const int nthreads = dafr_omp_get_max_threads_capped(ncol, threshold);
-    std::vector<std::vector<double>> tsum(nthreads,
-        std::vector<double>(nrow, 0.0));
-    std::vector<std::vector<int>>    tnnz(nthreads,
-        std::vector<int>(nrow, 0));
-
-    DAFR_PARALLEL_FOR(ncol >= threshold)
-    for (int j = 0; j < ncol; ++j) {
-        const int tid = dafr_omp_get_thread_num();
-        std::vector<double> &ts = tsum[tid];
-        std::vector<int>    &tn = tnnz[tid];
-        for (int k = pp[j]; k < pp[j + 1]; ++k) {
-            const int r = pi[k];
-            ts[r] += std::log(px[k] + eps);
-            tn[r] += 1;
-        }
-    }
-
-    // Initialise output to zero before serial reduction.
     for (int r = 0; r < nrow; ++r) pout[r] = 0.0;
     std::vector<int> nnz_per_row(nrow, 0);
 
-    for (int t = 0; t < nthreads; ++t) {
-        const std::vector<double> &ts = tsum[t];
-        const std::vector<int>    &tn = tnnz[t];
-        for (int r = 0; r < nrow; ++r) {
-            pout[r]        += ts[r];
-            nnz_per_row[r] += tn[r];
-        }
-    }
+    DAFR_OMP_PARALLEL_IF(nrow >= threshold)
+    {
+        const int tid = dafr_omp_get_thread_num();
+        const int nt  = dafr_omp_get_num_threads();
+        const int chunk = (nrow + nt - 1) / nt;
+        const int r0 = std::min(nrow, tid * chunk);
+        const int r1 = std::min(nrow, r0 + chunk);
 
-    DAFR_PARALLEL_FOR(nrow >= threshold)
-    for (int r = 0; r < nrow; ++r) {
-        double s = pout[r];
-        if (has_eps) {
-            s += (double)(ncol - nnz_per_row[r]) * log_eps;
-            pout[r] = std::exp(s / ncol) - eps;
-        } else {
-            pout[r] = std::exp(s / ncol);
+        // Pass 1: scan every column; filter by row-range.
+        for (int j = 0; j < ncol; ++j) {
+            const int k_end = pp[j + 1];
+            for (int k = pp[j]; k < k_end; ++k) {
+                const int r = pi[k];
+                if (r < r0 || r >= r1) continue;
+                pout[r] += std::log(px[k] + eps);
+                nnz_per_row[r] += 1;
+            }
+        }
+
+        // Pass 2: add zero contribution, derive geometric mean.
+        for (int r = r0; r < r1; ++r) {
+            double s = pout[r];
+            if (has_eps) {
+                s += (double)(ncol - nnz_per_row[r]) * log_eps;
+                pout[r] = std::exp(s / ncol) - eps;
+            } else {
+                pout[r] = std::exp(s / ncol);
+            }
         }
     }
     return out;

--- a/src/kernel_log_reduce.cpp
+++ b/src/kernel_log_reduce.cpp
@@ -75,52 +75,39 @@ cpp11::writable::doubles kernel_log_reduce_csc_cpp(
     const bool is_mean = (reducer == "Mean");
 
     if (axis == 0) {
+        // Row-partition: each thread owns a disjoint row range [r0, r1);
+        // writes to pout[r] and nnz_per_row[r] are race-free. No thread
+        // buckets, no serial merge.
         cpp11::writable::doubles out(nrow);
         double *pout = REAL(out.data());
-        // Each row receives:
-        //   sum_explicit = sum over nonzero entries in this row of log(x+eps)/log(base)
-        //   sum_zeros    = (ncol - nnz_in_this_row) * log(eps)/log(base)
-        // Total for Sum = sum_explicit + sum_zeros; Mean divides by ncol.
-        //
-        // Per-thread accumulator buffers avoid write contention on per-row
-        // counters. Post-parallel reduction is O(nthreads * nrow) — cheap
-        // vs O(nnz) for typical UMI matrices.
-        for (int r = 0; r < nrow; ++r) { pout[r] = 0.0; }
+        for (int r = 0; r < nrow; ++r) pout[r] = 0.0;
         std::vector<int> nnz_per_row(nrow, 0);
 
-        const int nthreads = dafr_omp_get_max_threads_capped(ncol, threshold);
-        std::vector<std::vector<double>> tsum(nthreads,
-            std::vector<double>(nrow, 0.0));
-        std::vector<std::vector<int>>    tnnz(nthreads,
-            std::vector<int>(nrow, 0));
-
-        DAFR_PARALLEL_FOR(ncol >= threshold)
-        for (int j = 0; j < ncol; ++j) {
+        DAFR_OMP_PARALLEL_IF(nrow >= threshold)
+        {
             const int tid = dafr_omp_get_thread_num();
-            std::vector<double> &ts = tsum[tid];
-            std::vector<int>    &tn = tnnz[tid];
-            for (int k = pp[j]; k < pp[j + 1]; ++k) {
-                const int r = pi[k];
-                ts[r] += std::log(px[k] + eps) * inv_log_base;
-                tn[r] += 1;
-            }
-        }
+            const int nt  = dafr_omp_get_num_threads();
+            const int chunk = (nrow + nt - 1) / nt;
+            const int r0 = std::min(nrow, tid * chunk);
+            const int r1 = std::min(nrow, r0 + chunk);
 
-        // Reduce thread buffers serially into outputs.
-        for (int t = 0; t < nthreads; ++t) {
-            const std::vector<double> &ts = tsum[t];
-            const std::vector<int>    &tn = tnnz[t];
-            for (int r = 0; r < nrow; ++r) {
-                pout[r]        += ts[r];
-                nnz_per_row[r] += tn[r];
+            // Pass 1: scan every column; filter by row-range.
+            for (int j = 0; j < ncol; ++j) {
+                const int k_end = pp[j + 1];
+                for (int k = pp[j]; k < k_end; ++k) {
+                    const int r = pi[k];
+                    if (r < r0 || r >= r1) continue;
+                    pout[r] += std::log(px[k] + eps) * inv_log_base;
+                    nnz_per_row[r] += 1;
+                }
             }
-        }
 
-        DAFR_PARALLEL_FOR(nrow >= threshold)
-        for (int r = 0; r < nrow; ++r) {
-            const int zeros = ncol - nnz_per_row[r];
-            pout[r] += zeros * zero_log;
-            if (is_mean) pout[r] /= ncol;
+            // Pass 2: add zero contributions, divide by ncol if Mean.
+            for (int r = r0; r < r1; ++r) {
+                const int zeros = ncol - nnz_per_row[r];
+                pout[r] += zeros * zero_log;
+                if (is_mean) pout[r] /= ncol;
+            }
         }
         return out;
     } else {

--- a/src/kernel_minmax_csc.cpp
+++ b/src/kernel_minmax_csc.cpp
@@ -45,41 +45,37 @@ cpp11::writable::doubles kernel_minmax_csc_cpp(
         return out;
     }
 
-    // axis == 0: per-row output. Thread-local buckets pattern from
-    // kernel_log_reduce_csc_cpp (see src/kernel_log_reduce.cpp:88-125).
+    // axis == 0: per-row output. Row-partition: each thread owns a
+    // disjoint row range [r0, r1); writes to pout[r] and nnz_per_row[r]
+    // are race-free. No thread buckets, no serial merge.
     cpp11::writable::doubles out(nrow);
     double *pout = REAL(out.data());
     for (int r = 0; r < nrow; ++r) pout[r] = sentinel;
     std::vector<int> nnz_per_row(nrow, 0);
 
-    const int nthreads = dafr_omp_get_max_threads_capped(ncol, threshold);
-    // FIXME: tbuf is O(nthreads × nrow) memory; at scRNA scale (nrow > 1e6)
-    // with many threads this may pressure RAM. Consider a sequential fallback
-    // for very large nrow.
-    std::vector<std::vector<double>> tbuf(nthreads,
-        std::vector<double>(nrow, sentinel));
-    std::vector<std::vector<int>> tnnz(nthreads, std::vector<int>(nrow, 0));
-
-    DAFR_PARALLEL_FOR(ncol >= threshold)
-    for (int j = 0; j < ncol; ++j) {
+    DAFR_OMP_PARALLEL_IF(nrow >= threshold)
+    {
         const int tid = dafr_omp_get_thread_num();
-        auto &tb = tbuf[tid];
-        auto &tn = tnnz[tid];
-        for (int k = pp[j]; k < pp[j + 1]; ++k) {
-            const int r = pi[k];
-            tb[r] = fold(tb[r], px[k]);
-            tn[r] += 1;
+        const int nt  = dafr_omp_get_num_threads();
+        const int chunk = (nrow + nt - 1) / nt;
+        const int r0 = std::min(nrow, tid * chunk);
+        const int r1 = std::min(nrow, r0 + chunk);
+
+        // Pass 1: scan every column; filter by row-range.
+        for (int j = 0; j < ncol; ++j) {
+            const int k_end = pp[j + 1];
+            for (int k = pp[j]; k < k_end; ++k) {
+                const int r = pi[k];
+                if (r < r0 || r >= r1) continue;
+                pout[r] = fold(pout[r], px[k]);
+                nnz_per_row[r] += 1;
+            }
         }
-    }
-    for (int t = 0; t < nthreads; ++t) {
-        for (int r = 0; r < nrow; ++r) {
-            pout[r] = fold(pout[r], tbuf[t][r]);
-            nnz_per_row[r] += tnnz[t][r];
+
+        // Pass 2: fold in implicit zero for rows with at least one.
+        for (int r = r0; r < r1; ++r) {
+            if (nnz_per_row[r] < ncol) pout[r] = fold(pout[r], 0.0);
         }
-    }
-    DAFR_PARALLEL_FOR(nrow >= threshold)
-    for (int r = 0; r < nrow; ++r) {
-        if (nnz_per_row[r] < ncol) pout[r] = fold(pout[r], 0.0);
     }
     return out;
 }

--- a/src/kernel_mode_csc.cpp
+++ b/src/kernel_mode_csc.cpp
@@ -105,98 +105,102 @@ cpp11::writable::doubles kernel_mode_csc_cpp(
     }
 
     // axis == 0: per-row (ReduceToColumn): one result per row.
-    // Collect nonzero values per row together with the column index at which
-    // they are first seen (column order == scan order for first-encountered).
-    // For implicit zeros per row, first_seen_col = first column that does NOT
-    // store this row.  We compute that lazily after collecting the data.
-
-    // per_row_vals[r] : nonzero values for row r (in column-scan order)
-    // per_row_cols[r] : column indices of the first occurrence of each distinct
-    //                   nonzero value for row r
-    // We store (col_idx, value) pairs per row; first col wins on ties.
+    // Row-partition: each thread owns a disjoint row range [r0, r1).
+    // The same thread fills rows[r] and computes out[r] for r in that
+    // range — no write race on rows[pi[k]], no cross-thread reads of
+    // rows[r] during post-process.
+    //
+    // Entry list per row: (col, val) pairs. Ordered by column because
+    // the owning thread scans j = 0..ncol-1 in ascending order. Mode's
+    // first-column-wins tie-break relies on this ordering.
     struct Entry { int col; double val; };
     std::vector<std::vector<Entry>> rows(nrow);
-    for (int j = 0; j < ncol; ++j) {
-        for (int k = pp[j]; k < pp[j + 1]; ++k) {
-            rows[pi[k]].push_back({j, px[k]});
-        }
-    }
-
-    // For each row, we also need to know the first column index at which a
-    // zero (implicit) appears.  Columns are scanned 0..ncol-1.  We can find
-    // this by looking at the sorted column indices stored for each row, then
-    // finding the first gap — exactly as for zero_row above but over columns.
-    // Since we built rows[r] in column order (j is increasing), we can walk
-    // the Entry list to find the first column not present.
 
     cpp11::writable::doubles out(nrow);
     double *pout = REAL(out.data());
 
-    DAFR_PARALLEL_FOR(nrow >= threshold)
-    for (int r = 0; r < nrow; ++r) {
-        const auto &entries = rows[r];
-        const int n_stored  = (int)entries.size();
-        const int n_zeros   = ncol - n_stored;
+    DAFR_OMP_PARALLEL_IF(nrow >= threshold)
+    {
+        const int tid = dafr_omp_get_thread_num();
+        const int nt  = dafr_omp_get_num_threads();
+        const int chunk = (nrow + nt - 1) / nt;
+        const int r0 = std::min(nrow, tid * chunk);
+        const int r1 = std::min(nrow, r0 + chunk);
 
-        // Find first_seen_col for implicit zero.
-        // entries are ordered by column (we inserted in j order).
-        int zero_first_col = std::numeric_limits<int>::max();
-        if (n_zeros > 0) {
-            // Walk stored columns looking for first gap.
-            if (n_stored == 0 || entries[0].col > 0) {
-                zero_first_col = 0;
-            } else {
-                zero_first_col = ncol; // default: no gap found yet
-                for (int k = 0; k < n_stored; ++k) {
-                    if (k + 1 < n_stored) {
-                        if (entries[k + 1].col > entries[k].col + 1) {
-                            zero_first_col = entries[k].col + 1;
-                            break;
-                        }
-                    } else {
-                        if (entries[k].col < ncol - 1) {
-                            zero_first_col = entries[k].col + 1;
+        // Pass 1: fill rows[r] for r in [r0, r1).
+        for (int j = 0; j < ncol; ++j) {
+            const int k_end = pp[j + 1];
+            for (int k = pp[j]; k < k_end; ++k) {
+                const int r = pi[k];
+                if (r < r0 || r >= r1) continue;
+                rows[r].push_back({j, px[k]});
+            }
+        }
+
+        // Pass 2: compute mode for rows in [r0, r1).
+        for (int r = r0; r < r1; ++r) {
+            const auto &entries = rows[r];
+            const int n_stored  = (int)entries.size();
+            const int n_zeros   = ncol - n_stored;
+
+            // Find first_seen_col for implicit zero.
+            // entries are ordered by column (we inserted in j order).
+            int zero_first_col = std::numeric_limits<int>::max();
+            if (n_zeros > 0) {
+                if (n_stored == 0 || entries[0].col > 0) {
+                    zero_first_col = 0;
+                } else {
+                    zero_first_col = ncol; // default: no gap found yet
+                    for (int k = 0; k < n_stored; ++k) {
+                        if (k + 1 < n_stored) {
+                            if (entries[k + 1].col > entries[k].col + 1) {
+                                zero_first_col = entries[k].col + 1;
+                                break;
+                            }
+                        } else {
+                            if (entries[k].col < ncol - 1) {
+                                zero_first_col = entries[k].col + 1;
+                            }
                         }
                     }
                 }
             }
-        }
 
-        // Build count and first_col maps for nonzero values.
-        std::unordered_map<double, int> counts;
-        std::unordered_map<double, int> first_col;
-        counts.reserve(n_stored);
-        first_col.reserve(n_stored);
-        for (const auto &e : entries) {
-            auto it = counts.find(e.val);
-            if (it == counts.end()) {
-                counts[e.val]    = 1;
-                first_col[e.val] = e.col;
-            } else {
-                it->second += 1;
+            // Build count and first_col maps for nonzero values.
+            std::unordered_map<double, int> counts;
+            std::unordered_map<double, int> first_col;
+            counts.reserve(n_stored);
+            first_col.reserve(n_stored);
+            for (const auto &e : entries) {
+                auto it = counts.find(e.val);
+                if (it == counts.end()) {
+                    counts[e.val]    = 1;
+                    first_col[e.val] = e.col;
+                } else {
+                    it->second += 1;
+                }
             }
-        }
 
-        double best_val      = 0.0;
-        int    best_count    = n_zeros;
-        int    best_first_col = zero_first_col;
-        // If no zeros at all, initialise with something that will be displaced.
-        if (n_zeros == 0) {
-            best_count     = 0;
-            best_first_col = std::numeric_limits<int>::max();
-        }
-
-        for (auto &kv : counts) {
-            int cnt = kv.second;
-            int fc  = first_col[kv.first];
-            if (cnt > best_count ||
-                (cnt == best_count && fc < best_first_col)) {
-                best_count     = cnt;
-                best_val       = kv.first;
-                best_first_col = fc;
+            double best_val      = 0.0;
+            int    best_count    = n_zeros;
+            int    best_first_col = zero_first_col;
+            if (n_zeros == 0) {
+                best_count     = 0;
+                best_first_col = std::numeric_limits<int>::max();
             }
+
+            for (auto &kv : counts) {
+                int cnt = kv.second;
+                int fc  = first_col[kv.first];
+                if (cnt > best_count ||
+                    (cnt == best_count && fc < best_first_col)) {
+                    best_count     = cnt;
+                    best_val       = kv.first;
+                    best_first_col = fc;
+                }
+            }
+            pout[r] = best_val;
         }
-        pout[r] = best_val;
     }
     return out;
 }

--- a/src/kernel_mode_csc.cpp
+++ b/src/kernel_mode_csc.cpp
@@ -116,6 +116,27 @@ cpp11::writable::doubles kernel_mode_csc_cpp(
     struct Entry { int col; double val; };
     std::vector<std::vector<Entry>> rows(nrow);
 
+    // Pre-size rows[r] from a serial nnz-per-row count. The parallel
+    // push_back below never hits the allocator because capacity is
+    // already sufficient — that avoids the capacity-doubling path in
+    // std::vector::push_back, which under 128 threads induces heavy
+    // malloc contention. Measured wall-time impact at nr=100k, nc=5k,
+    // density=0.02: ~2.5x speedup (0.286s -> 0.111s). Peak RSS is
+    // unchanged within noise — the post-process per-row unordered_map
+    // allocations dominate mode's memory footprint, not the fill.
+    {
+        std::vector<int> nnz_per_row(nrow, 0);
+        for (int j = 0; j < ncol; ++j) {
+            const int k_end = pp[j + 1];
+            for (int k = pp[j]; k < k_end; ++k) {
+                ++nnz_per_row[pi[k]];
+            }
+        }
+        for (int r = 0; r < nrow; ++r) {
+            rows[r].reserve(nnz_per_row[r]);
+        }
+    }
+
     cpp11::writable::doubles out(nrow);
     double *pout = REAL(out.data());
 

--- a/src/kernel_quantile_csc.cpp
+++ b/src/kernel_quantile_csc.cpp
@@ -113,52 +113,65 @@ cpp11::writable::doubles kernel_quantile_csc_cpp(
         return out;
     }
 
-    // axis == 0: per-row. Collect each row's non-zero values first (one-pass
-    // CSC traversal), then compute per-row quantile.
+    // axis == 0: per-row. Collect each row's non-zero values first, then
+    // compute per-row quantile. Row-partition: each thread owns a disjoint
+    // row range [r0, r1); writes to rows[pi[k]] are race-free because slot
+    // ownership is fixed by r. The same thread that fills rows[r] also
+    // computes out[r], so no cross-thread reads of rows[r].
     std::vector<std::vector<double>> rows(nrow);
-    // Pre-size to avoid reallocation noise; nnz / nrow ≈ density * ncol.
-    // (No parallelism here; writes to rows[pi[k]] would race across threads.)
-    for (int j = 0; j < ncol; ++j) {
-        for (int k = pp[j]; k < pp[j + 1]; ++k) {
-            rows[pi[k]].push_back(px[k]);
-        }
-    }
 
     cpp11::writable::doubles out(nrow);
     double* pout = REAL(out.data());
 
-    // Second pass: per-row quantile. Safe to parallelise — each row's vector
-    // is fully built and rows are independent.
-    DAFR_PARALLEL_FOR(nrow >= threshold)
-    for (int r = 0; r < nrow; ++r) {
-        const int n = ncol;
-        if (n == 0) { pout[r] = 0.0; continue; }
-        const auto& rv = rows[r];
-        std::vector<double> neg, pos;
-        neg.reserve(rv.size());
-        pos.reserve(rv.size());
-        for (double v : rv) {
-            if (v < 0.0) neg.push_back(v);
-            else if (v > 0.0) pos.push_back(v);
+    DAFR_OMP_PARALLEL_IF(nrow >= threshold)
+    {
+        const int tid = dafr_omp_get_thread_num();
+        const int nt  = dafr_omp_get_num_threads();
+        const int chunk = (nrow + nt - 1) / nt;
+        const int r0 = std::min(nrow, tid * chunk);
+        const int r1 = std::min(nrow, r0 + chunk);
+
+        // Pass 1: fill rows[r] for r in [r0, r1).
+        for (int j = 0; j < ncol; ++j) {
+            const int k_end = pp[j + 1];
+            for (int k = pp[j]; k < k_end; ++k) {
+                const int r = pi[k];
+                if (r < r0 || r >= r1) continue;
+                rows[r].push_back(px[k]);
+            }
         }
-        const int n_zeros = n - static_cast<int>(neg.size()) -
-                                static_cast<int>(pos.size());
-        const double h = q * (n - 1);
-        const int lo = static_cast<int>(std::floor(h));
-        const int hi = static_cast<int>(std::ceil(h));
-        const double frac = h - lo;
-        if (lo == hi) {
-            pout[r] = pick_rank(neg, pos, n_zeros, lo);
-        } else {
-            const double v_lo = pick_rank(neg, pos, n_zeros, lo);
-            // Rebuild for hi pick.
-            neg.clear(); pos.clear();
+
+        // Pass 2: compute quantile for rows in [r0, r1).
+        for (int r = r0; r < r1; ++r) {
+            const int n = ncol;
+            if (n == 0) { pout[r] = 0.0; continue; }
+            const auto& rv = rows[r];
+            std::vector<double> neg, pos;
+            neg.reserve(rv.size());
+            pos.reserve(rv.size());
             for (double v : rv) {
                 if (v < 0.0) neg.push_back(v);
                 else if (v > 0.0) pos.push_back(v);
             }
-            const double v_hi = pick_rank(neg, pos, n_zeros, hi);
-            pout[r] = (1.0 - frac) * v_lo + frac * v_hi;
+            const int n_zeros = n - static_cast<int>(neg.size()) -
+                                    static_cast<int>(pos.size());
+            const double h = q * (n - 1);
+            const int lo = static_cast<int>(std::floor(h));
+            const int hi = static_cast<int>(std::ceil(h));
+            const double frac = h - lo;
+            if (lo == hi) {
+                pout[r] = pick_rank(neg, pos, n_zeros, lo);
+            } else {
+                const double v_lo = pick_rank(neg, pos, n_zeros, lo);
+                // Rebuild for hi pick.
+                neg.clear(); pos.clear();
+                for (double v : rv) {
+                    if (v < 0.0) neg.push_back(v);
+                    else if (v > 0.0) pos.push_back(v);
+                }
+                const double v_hi = pick_rank(neg, pos, n_zeros, hi);
+                pout[r] = (1.0 - frac) * v_lo + frac * v_hi;
+            }
         }
     }
     return out;

--- a/src/kernel_quantile_csc.cpp
+++ b/src/kernel_quantile_csc.cpp
@@ -120,6 +120,23 @@ cpp11::writable::doubles kernel_quantile_csc_cpp(
     // computes out[r], so no cross-thread reads of rows[r].
     std::vector<std::vector<double>> rows(nrow);
 
+    // Pre-size rows[r] from a serial nnz-per-row count so the parallel
+    // push_back below never hits the capacity-doubling path in
+    // std::vector::push_back — that path induces heavy malloc
+    // contention across 128 threads. Keeps the parallel-fill win clean.
+    {
+        std::vector<int> nnz_per_row(nrow, 0);
+        for (int j = 0; j < ncol; ++j) {
+            const int k_end = pp[j + 1];
+            for (int k = pp[j]; k < k_end; ++k) {
+                ++nnz_per_row[pi[k]];
+            }
+        }
+        for (int r = 0; r < nrow; ++r) {
+            rows[r].reserve(nnz_per_row[r]);
+        }
+    }
+
     cpp11::writable::doubles out(nrow);
     double* pout = REAL(out.data());
 

--- a/src/kernel_var_csc.cpp
+++ b/src/kernel_var_csc.cpp
@@ -49,40 +49,40 @@ cpp11::writable::doubles kernel_var_csc_cpp(
         return out;
     }
 
-    // axis == 0: per-row. Thread buckets for sum_x, sum_x2.
-    // FIXME: tbuf is O(nthreads * nrow). For scRNA-seq-scale inputs
-    // (nrow > 1e6), consider a sequential fallback.
+    // axis == 0: per-row. Row-partition: each thread owns a disjoint row
+    // range [r0, r1); two threads never write to the same sx_tot/sxx_tot
+    // slot. No thread buckets, no serial merge.
     cpp11::writable::doubles out(nrow);
     double *pout = REAL(out.data());
     std::vector<double> sx_tot(nrow, 0.0), sxx_tot(nrow, 0.0);
 
-    const int nthreads = dafr_omp_get_max_threads_capped(ncol, threshold);
-    std::vector<std::vector<double>> tsx(nthreads, std::vector<double>(nrow, 0.0));
-    std::vector<std::vector<double>> tsxx(nthreads, std::vector<double>(nrow, 0.0));
-
-    DAFR_PARALLEL_FOR(ncol >= threshold)
-    for (int j = 0; j < ncol; ++j) {
+    DAFR_OMP_PARALLEL_IF(nrow >= threshold)
+    {
         const int tid = dafr_omp_get_thread_num();
-        auto &tsa = tsx[tid];
-        auto &tsb = tsxx[tid];
-        for (int k = pp[j]; k < pp[j + 1]; ++k) {
-            const int r = pi[k];
-            const double v = px[k];
-            tsa[r] += v;
-            tsb[r] += v * v;
+        const int nt  = dafr_omp_get_num_threads();
+        const int chunk = (nrow + nt - 1) / nt;
+        const int r0 = std::min(nrow, tid * chunk);
+        const int r1 = std::min(nrow, r0 + chunk);
+
+        // Pass 1: scan every column; filter by row-range.
+        for (int j = 0; j < ncol; ++j) {
+            const int k_end = pp[j + 1];
+            for (int k = pp[j]; k < k_end; ++k) {
+                const int r = pi[k];
+                if (r < r0 || r >= r1) continue;
+                const double v = px[k];
+                sx_tot[r]  += v;
+                sxx_tot[r] += v * v;
+            }
         }
-    }
-    for (int t = 0; t < nthreads; ++t) {
-        for (int r = 0; r < nrow; ++r) {
-            sx_tot[r]  += tsx[t][r];
-            sxx_tot[r] += tsxx[t][r];
+
+        // Pass 2: post-process rows in [r0, r1). Each thread owns the
+        // reads and writes for its row range.
+        for (int r = r0; r < r1; ++r) {
+            const double mean = ncol > 0 ? sx_tot[r] / ncol : 0.0;
+            const double var_u = ncol > 0 ? (sxx_tot[r] / ncol - mean * mean) : 0.0;
+            pout[r] = derive(variant, var_u < 0 ? 0.0 : var_u, mean, eps);
         }
-    }
-    DAFR_PARALLEL_FOR(nrow >= threshold)
-    for (int r = 0; r < nrow; ++r) {
-        const double mean = ncol > 0 ? sx_tot[r] / ncol : 0.0;
-        const double var_u = ncol > 0 ? (sxx_tot[r] / ncol - mean * mean) : 0.0;
-        pout[r] = derive(variant, var_u < 0 ? 0.0 : var_u, mean, eps);
     }
     return out;
 }

--- a/tests/testthat/test-kernel-csc-axis0-memory.R
+++ b/tests/testthat/test-kernel-csc-axis0-memory.R
@@ -1,0 +1,134 @@
+# Slice 9d-N regression guards for the CSC axis=0 row-partition rewrite.
+# Two test_that blocks:
+#   1. Bit-identity: parallel dispatch (threshold = 1L) matches serial
+#      dispatch (threshold = .Machine$integer.max) on a 2k x 2k fixture
+#      for all six row-partitioned kernels.
+#   2. Peak-RSS: at the larger 100k x 5k fixture, one representative
+#      category-A kernel stays under a 100 MB bench_process_memory delta.
+#      Pre-fix the thread-bucket pattern would allocate 128 * 100k * 16B
+#      ~= 200 MB at 128 threads - reintroducing it will fail this test.
+
+test_that("CSC axis=0 row-partition is bit-identical to serial dispatch", {
+    skip_on_cran()
+    set.seed(42L)
+    nr <- 2000L
+    nc <- 2000L
+    nnz <- as.integer(nr * nc * 0.02)
+    m <- Matrix::sparseMatrix(
+        i = sample.int(nr, nnz, replace = TRUE),
+        j = sample.int(nc, nnz, replace = TRUE),
+        x = runif(nnz, 0.1, 10.0),
+        dims = c(nr, nc),
+        repr = "C"
+    )
+
+    # kernel_var_csc - all four variants share the axis=0 path.
+    for (variant in c("Var", "Std", "VarN", "StdN")) {
+        par <- kernel_var_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                                  axis = 0L, variant = variant, eps = 1e-6,
+                                  threshold = 1L)
+        ser <- kernel_var_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                                  axis = 0L, variant = variant, eps = 1e-6,
+                                  threshold = .Machine$integer.max)
+        expect_identical(par, ser)
+    }
+
+    # kernel_minmax_csc - Min and Max.
+    for (variant in c("Min", "Max")) {
+        par <- kernel_minmax_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                                     axis = 0L, variant = variant,
+                                     threshold = 1L)
+        ser <- kernel_minmax_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                                     axis = 0L, variant = variant,
+                                     threshold = .Machine$integer.max)
+        expect_identical(par, ser)
+    }
+
+    # kernel_log_reduce - Sum and Mean reducers.
+    for (reducer in c("Sum", "Mean")) {
+        par <- kernel_log_reduce_csc_cpp(
+            m@x, m@i, m@p, nrow(m), ncol(m),
+            eps = 1e-5, base = 2,
+            axis = 0L, reducer = reducer, threshold = 1L
+        )
+        ser <- kernel_log_reduce_csc_cpp(
+            m@x, m@i, m@p, nrow(m), ncol(m),
+            eps = 1e-5, base = 2,
+            axis = 0L, reducer = reducer,
+            threshold = .Machine$integer.max
+        )
+        expect_identical(par, ser)
+    }
+
+    # kernel_geomean_csc - both eps > 0 and eps == 0 paths.
+    for (eps in c(0, 1e-6)) {
+        par <- kernel_geomean_csc_cpp(
+            m@x, m@i, m@p, nrow(m), ncol(m),
+            axis = 0L, eps = eps, threshold = 1L
+        )
+        ser <- kernel_geomean_csc_cpp(
+            m@x, m@i, m@p, nrow(m), ncol(m),
+            axis = 0L, eps = eps,
+            threshold = .Machine$integer.max
+        )
+        expect_identical(par, ser)
+    }
+
+    # kernel_mode_csc - single axis=0 path.
+    par_mode <- kernel_mode_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                                    axis = 0L, threshold = 1L)
+    ser_mode <- kernel_mode_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                                    axis = 0L,
+                                    threshold = .Machine$integer.max)
+    expect_identical(par_mode, ser_mode)
+
+    # kernel_quantile_csc - q = 0.5 (median); q-choice does not affect
+    # the fill-pass parallelism under test.
+    par_q <- kernel_quantile_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                                     axis = 0L, q = 0.5, threshold = 1L)
+    ser_q <- kernel_quantile_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                                     axis = 0L, q = 0.5,
+                                     threshold = .Machine$integer.max)
+    expect_identical(par_q, ser_q)
+})
+
+test_that("kernel_var_csc axis=0 peak RSS stays under 100 MB on stress fixture", {
+    skip_on_cran()
+    skip_if_not_installed("bench")
+
+    # NOTE: libgomp caches max_threads at DSO-load time, so a runtime
+    # Sys.setenv(OMP_NUM_THREADS=...) does NOT change the thread count.
+    # The test asserts peak RSS under whatever thread count libgomp
+    # picked up - typically parallel::detectCores(). On a 128-thread
+    # dev machine that means 128 threads; on an 8-thread CI box, 8.
+    # Pre-fix the O(nthreads * nrow) bucket pattern allocated 16 B per
+    # (thread, row); at 128 threads x 100k rows that is ~200 MB, well
+    # over this 100 MB budget. Post-fix the footprint is bounded by the
+    # output shape plus two nrow-sized double vectors (1.6 MB total).
+
+    set.seed(42L)
+    nr <- 100000L
+    nc <- 5000L
+    nnz <- as.integer(nr * nc * 0.02)
+    m <- Matrix::sparseMatrix(
+        i = sample.int(nr, nnz, replace = TRUE),
+        j = sample.int(nc, nnz, replace = TRUE),
+        x = runif(nnz, 0.1, 10.0),
+        dims = c(nr, nc),
+        repr = "C"
+    )
+
+    gc(full = TRUE)
+    mem_before <- bench::bench_process_memory()
+    out <- kernel_var_csc_cpp(m@x, m@i, m@p, nrow(m), ncol(m),
+                              axis = 0L, variant = "Var", eps = 0,
+                              threshold = 1L)
+    mem_after <- bench::bench_process_memory()
+
+    delta <- as.numeric(mem_after["max"]) - as.numeric(mem_before["max"])
+    expect_lt(delta, 100 * 1024 * 1024)
+
+    # Sanity: output shape and finite values.
+    expect_equal(length(out), nr)
+    expect_true(all(is.finite(out)))
+})


### PR DESCRIPTION
Extends the 9d-M row-partition technique to six non-grouped CSC
kernels:

- **Category A (thread-bucket)**: `kernel_var_csc`, `kernel_minmax_csc`,
  `kernel_log_reduce`, `kernel_geomean_csc` — replace the
  `O(nthreads x nrow)` thread-local accumulator pattern with a shared
  accumulator + row-partitioned writes.
- **Category B (serial fill)**: `kernel_mode_csc`, `kernel_quantile_csc` —
  parallelise the previously-serial fill pass and fold post-process into
  the same `DAFR_OMP_PARALLEL_IF` region. A serial nnz-per-row count +
  reserve avoids capacity-doubling contention in `std::vector::push_back`
  under 128 threads.

## Profile — 100k x 5k x 0.02 fixture, 128 threads

| kernel | pre wall | post wall | speedup |
|---|---:|---:|---:|
| `kernel_var_csc` (Var) | 0.113s | 0.026s | 4.3x |
| `kernel_minmax_csc` (Max) | 0.086s | 0.024s | 3.6x |
| `kernel_log_reduce` (Sum) | 0.086s | 0.028s | 3.1x |
| `kernel_geomean_csc` | 0.087s | 0.024s | 3.6x |
| `kernel_mode_csc` | 0.275s | 0.108s | 2.5x |
| `kernel_quantile_csc` (q=0.5) | 0.138s | 0.044s | 3.1x |

Peak process RSS at 128 threads unchanged (694 MB both pre and post);
`kernel_var_csc` RSS delta drops 196 MB.

## Correctness

Bit-identity between parallel (`threshold = 1L`) and serial
(`threshold = .Machine$integer.max`) dispatch holds for all six
kernels — each row is owned by one thread which scans columns in
ascending order, so floating-point summation order matches the
serial path.

New test file `tests/testthat/test-kernel-csc-axis0-memory.R` has
two `test_that` blocks:
1. Bit-identity across all six kernels on a 2k x 2k fixture.
2. Peak-RSS budget (<100 MB) on `kernel_var_csc` at a 100k x 5k
   fixture. Pre-fix pattern would blow this budget at 128 threads.

Both use `skip_on_cran()` and run on dev hardware only (CI uses
`--as-cran`, same pattern as the 9d-M stress tests).

## Test plan
- [x] Full test suite green: `[ FAIL 1 | WARN 1 | SKIP 0 | PASS 1931 ]` with `NOT_CRAN=true`. The single `FAIL` is the pre-existing `test-helpers.R:26` S4 trace test which skips under `R CMD check`.
- [x] Pre-fix and post-fix profiles recorded in `dev/benchmarks/2026-04-22-{pre,post}-slice-9d-n*/`.
- [x] No bake-off impact (`OMP_NUM_THREADS=1` path unchanged).