### PR TITLE
docs(pkgdown): add ZipDaf topics to reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -40,10 +40,13 @@ reference:
       - ZarrDaf
       - ZarrDafReadOnly
       - HttpDaf
+      - ZipDaf
+      - ZipDafReadOnly
       - memory_daf
       - files_daf
       - zarr_daf
       - http_daf
+      - zip_daf
       - pack_files_daf_metadata
       - is_daf
       - is_leaf


### PR DESCRIPTION
## Summary

The pkgdown push-to-main workflow failed after #9 merged: `check_missing_topics`
aborted because the 3 new 0.6.0 exports (`ZipDaf`, `ZipDafReadOnly`, `zip_daf`)
were not listed in `_pkgdown.yml`. Add them to the "Core data model" section
alongside the other backends.

(R-CMD-check and altrep-sanity passed on the #9 push; only pkgdown failed.
pkgdown runs on push-to-main, not on PRs, so it re-runs green once this merges.)

## Test plan

- [x] `pkgdown::check_pkgdown(".")` -> "✔ No problems found."

https://claude.ai/code/session_013CEMsVoeh6FpsysEWowYw2